### PR TITLE
fix: update application name in environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Application Configuration
-APP_NAME="Simple FastAPI"
+APP_NAME="An Simple FastAPI"
 DEBUG=false
 HOST=0.0.0.0
 PORT=8000


### PR DESCRIPTION
- Changed APP_NAME from 'Simple FastAPI' to 'An Simple FastAPI'
- Updated environment configuration template